### PR TITLE
Add script to release the SDK along the OpenAPI spec

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release LocalStack Python Client
 
 on:
+  repository_dispatch:
+    types: [release-sdk]
   workflow_dispatch:
     inputs:
       version:
@@ -8,7 +10,6 @@ on:
         required: true
 
 env:
-  TAG_VERSION: "${{ inputs.version }}"
   git_user_name: localstack[bot]
   git_user_email: localstack-bot@users.noreply.github.com
 
@@ -16,106 +17,128 @@ jobs:
 
   test_python:
     runs-on: ubuntu-latest
+    env:
+      release: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.event.client_payload.version}}
 
     steps:
-    - name: Verify OpenAPI version
+    - name: "Set the URL of the spec"
       run: |
-        SPEC_URL=https://github.com/localstack/openapi/releases/download/${{ env.TAG_VERSION }}/localstack-spec.yml
+        echo "SPEC_URL=https://github.com/localstack/openapi/releases/download/v${{ env.release }}/localstack-spec.yml" >> $GITHUB_ENV
+
+    - name: "Verify OpenAPI version"
+      run: |
         # Check if the URL is valid
-        if ! wget --spider -q "$SPEC_URL"; then
-          echo "Invalid spec to build from: $SPEC_URL. Aborting ..."
+        if ! wget --spider -q "${SPEC_URL}"; then
+          echo "Invalid spec to build from: ${SPEC_URL}. Aborting ..."
           exit 1
         fi
-        
-        echo "VERSION=${TAG_VERSION#v}" >> $GITHUB_ENV
 
-    - name: Pull image
+    - name: "Pull image"
       run: |
-        docker pull localstack/localstack-pro:${VERSION}
+        docker pull localstack/localstack-pro:${{ env.release }}
 
-    - name: Checkout
+    - name: "Checkout"
       uses: actions/checkout@v4
       with:
         # setuptools_scm requires git history to determine the version
         fetch-depth: 0
 
-    - name: Set up Python 3.11
+    - name: "Set up Python 3.11"
       uses: actions/setup-python@v5
       with:
         python-version: "3.11"
 
-    - name: Install uv
+    - name: "Install uv"
       uses: astral-sh/setup-uv@v3
 
-    - name: Generate code from spec
+    - name: "Generate code from spec"
       run: |
         make clean-generated
-        ./bin/generate https://github.com/localstack/openapi/releases/download/${{ env.TAG_VERSION }}/localstack-spec.yml
+        ./bin/generate.sh ${SPEC_URL}
 
-    - name: Install project
+    - name: "Prepare git config"
+      run: |
+        git config user.name ${{ env.git_user_name }}
+        git config user.email ${{ env.git_user_email }}
+
+    - name: "Commit changed code"
+      run: |
+        if git status --porcelain packages/ | grep -q '^'; then
+          git add packages/
+          git commit -m "Generate code for ${{ env.release }}"
+
+          echo "Changes committed successfully"
+        else
+          echo "No changes detected after generating the code"
+        fi
+
+    - name: "Install project"
       run: |
         make install-dev
 
-    - name: Install LocalStack
+    - name: "Install LocalStack"
       run: |
-        pip install localstack==${{ env.TAG_VERSION }}
+        pip install localstack==${{ env.release }}
 
-    - name: Start Localstack
+    - name: "Start Localstack"
       env:
        LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
       run: |
           source .venv/bin/activate
-          DEBUG=1 DISABLE_EVENTS="1" IMAGE_NAME="localstack/localstack-pro:${VERSION}" localstack start -d
+          DEBUG=1 DISABLE_EVENTS="1" IMAGE_NAME="localstack/localstack-pro:${{ env.release }}" localstack start -d
           localstack wait -t 120 || (python -m localstack.cli.main logs && false)
 
-    - name: Run Python Tests
+    - name: "Run Python Tests"
       env:
         LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
       run: |
         make test
 
-    - name: Stop Localstack
+    - name: "Stop Localstack"
       if: always()
       run: |
           source .venv/bin/activate
           localstack logs
           localstack stop
 
-    - name: Install release helper
+    - name: "Install release helper"
       run: |
         curl -o bin/release-helper.sh -L https://api.github.com/repos/localstack/localstack/contents/bin/release-helper.sh -H 'Accept: application/vnd.github.v3.raw'
         chmod +x bin/release-helper.sh
 
-    - name: Create the release commit and tag
+    - name: "Create the release commit and tag"
       run: |
-        bin/release-helper.sh git-commit-release ${{ env.TAG_VERSION }}
+        bin/release-helper.sh git-commit-release ${{ env.release }}
 
-    - name: Publish release to pypi
+    - name: "Publish release to pypi"
       run: |
         make clean && make install
         make publish
       with:
         UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
 
-    - name: Push the release commit and tag
+    - name: "Push the release commit and tag"
       run: |
         git push --follow-tags
 
-    - name: Create GitHub release
+    - name: "Create GitHub release"
       env:
         GITHUB_TOKEN: ${{ secrets.LOCALSTACK_GITHUB_TOKEN }}
-      run: gh release create "${{ env.TAG_VERSION }}" --generate-notes --draft
+      run: gh release create "${{ env.release }}" --generate-notes --draft
 
-    - name: Commit and push next development version
+    - name: "Commit and push next development version"
       run: |
         bin/release-helper.sh git-commit-increment
         git push
 
-    - name: Publish development version to pypi
-      run: make install && make publish
+    - name: "Publish development version to pypi"
+      run: |
+        make install && make publish
+      with:
+        UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
 
     - name: "Show git modifications"
       run: |
-        git log --oneline -n 3
+        git log --oneline -n 4
         git show HEAD~1
         git show HEAD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ jobs:
 
     - name: "Commit changed code"
       run: |
+        # Code automatically generated goes into the packages directory.
+        # As we generate code for the version to be released, we commit those changes.
         if git status --porcelain packages/ | grep -q '^'; then
           git add packages/
           git commit -m "Generate code for ${{ env.release }}"
@@ -100,8 +102,7 @@ jobs:
 
     - name: "Publish release to pypi"
       run: |
-        make clean && make install
-        make publish
+        make install publish
       with:
         UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
         make test
 
     - name: "Stop Localstack"
-      if: always()
+      if: success() || failure()
       run: |
           source .venv/bin/activate
           localstack logs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,121 @@
+name: Release LocalStack Python Client
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version of the OpenAPI spec to release the client for
+        required: true
+
+env:
+  TAG_VERSION: "${{ inputs.version }}"
+  git_user_name: localstack[bot]
+  git_user_email: localstack-bot@users.noreply.github.com
+
+jobs:
+
+  test_python:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Verify OpenAPI version
+      run: |
+        SPEC_URL=https://github.com/localstack/openapi/releases/download/${{ env.TAG_VERSION }}/localstack-spec.yml
+        # Check if the URL is valid
+        if ! wget --spider -q "$SPEC_URL"; then
+          echo "Invalid spec to build from: $SPEC_URL. Aborting ..."
+          exit 1
+        fi
+        
+        echo "VERSION=${TAG_VERSION#v}" >> $GITHUB_ENV
+
+    - name: Pull image
+      run: |
+        docker pull localstack/localstack-pro:${VERSION}
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        # setuptools_scm requires git history to determine the version
+        fetch-depth: 0
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+
+    - name: Generate code from spec
+      run: |
+        make clean-generated
+        ./bin/generate https://github.com/localstack/openapi/releases/download/${{ env.TAG_VERSION }}/localstack-spec.yml
+
+    - name: Install project
+      run: |
+        make install-dev
+
+    - name: Install LocalStack
+      run: |
+        pip install localstack==${{ env.TAG_VERSION }}
+
+    - name: Start Localstack
+      env:
+       LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+      run: |
+          source .venv/bin/activate
+          DEBUG=1 DISABLE_EVENTS="1" IMAGE_NAME="localstack/localstack-pro:${VERSION}" localstack start -d
+          localstack wait -t 120 || (python -m localstack.cli.main logs && false)
+
+    - name: Run Python Tests
+      env:
+        LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+      run: |
+        make test
+
+    - name: Stop Localstack
+      if: always()
+      run: |
+          source .venv/bin/activate
+          localstack logs
+          localstack stop
+
+    - name: Install release helper
+      run: |
+        curl -o bin/release-helper.sh -L https://api.github.com/repos/localstack/localstack/contents/bin/release-helper.sh -H 'Accept: application/vnd.github.v3.raw'
+        chmod +x bin/release-helper.sh
+
+    - name: Create the release commit and tag
+      run: |
+        bin/release-helper.sh git-commit-release ${{ env.TAG_VERSION }}
+
+    - name: Publish release to pypi
+      run: |
+        make clean && make install
+        make publish
+      with:
+        UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
+
+    - name: Push the release commit and tag
+      run: |
+        git push --follow-tags
+
+    - name: Create GitHub release
+      env:
+        GITHUB_TOKEN: ${{ secrets.LOCALSTACK_GITHUB_TOKEN }}
+      run: gh release create "${{ env.TAG_VERSION }}" --generate-notes --draft
+
+    - name: Commit and push next development version
+      run: |
+        bin/release-helper.sh git-commit-increment
+        git push
+
+    - name: Publish development version to pypi
+      run: make install && make publish
+
+    - name: "Show git modifications"
+      run: |
+        git log --oneline -n 3
+        git show HEAD~1
+        git show HEAD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,18 +21,6 @@ jobs:
       release: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.event.client_payload.version}}
 
     steps:
-    - name: "Set the URL of the spec"
-      run: |
-        echo "SPEC_URL=https://github.com/localstack/openapi/releases/download/v${{ env.release }}/localstack-spec.yml" >> $GITHUB_ENV
-
-    - name: "Verify OpenAPI version"
-      run: |
-        # Check if the URL is valid
-        if ! wget --spider -q "${SPEC_URL}"; then
-          echo "Invalid spec to build from: ${SPEC_URL}. Aborting ..."
-          exit 1
-        fi
-
     - name: "Pull image"
       run: |
         docker pull localstack/localstack-pro:${{ env.release }}
@@ -54,7 +42,7 @@ jobs:
     - name: "Generate code from spec"
       run: |
         make clean-generated
-        ./bin/generate.sh ${SPEC_URL}
+        ./bin/generate.sh ${{ env.release }}
 
     - name: "Prepare git config"
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
 
     - name: "Publish development version to pypi"
       run: |
-        make install && make publish
+        make install publish
       with:
         UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ localstack-sdk-python-2/.openapi-generator/
 
 # setuptools_scm version.py
 **/version.py
+
+# release helper
+bin/release-helper.sh

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,20 @@ clean:         		## Clean up the virtual environment
 	rm -rf $(VENV_DIR)
 	rm -rf dist/
 
+clean-dist:
+    rm -rf dist/
+
 clean-generated:	## Cleanup generated code
 	rm -rf packages/localstack-sdk-generated/localstack/
 
 generate:			## Generate the code from the OpenAPI specs
 	./bin/generate.sh
+
+build:
+    uv build
+
+publish: clean-dist build
+    uv publish
 
 format:
 	($(VENV_RUN); python -m ruff format --exclude packages .; python -m ruff check --output-format=full --exclude packages --fix .)
@@ -32,4 +41,4 @@ lint:
 test:              		  ## Run automated tests
 	($(VENV_RUN); $(TEST_EXEC) pytest --durations=10 --log-cli-level=$(PYTEST_LOGLEVEL) $(PYTEST_ARGS) $(TEST_PATH))
 
-.PHONY: clean install install-dev
+.PHONY: clean install install-dev clean clean-dist clean-generated generate build publish format lint test

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ clean:         		## Clean up the virtual environment
 	rm -rf dist/
 
 clean-dist:
-    rm -rf dist/
+	rm -rf dist/
 
 clean-generated:	## Cleanup generated code
 	rm -rf packages/localstack-sdk-generated/localstack/
@@ -27,10 +27,10 @@ generate:			## Generate the code from the OpenAPI specs
 	./bin/generate.sh
 
 build:
-    uv build
+	uv build
 
 publish: clean-dist build
-    uv publish
+	uv publish
 
 format:
 	($(VENV_RUN); python -m ruff format --exclude packages .; python -m ruff check --output-format=full --exclude packages --fix .)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To run the integration test suite:
 make test
 ```
 
-Note that LocalStack (pro) should be running in the background to execute the test.
+Note that LocalStack Pro (with the same version as the SDK) should be running in the background to execute the test.
 
 ### Quickstart
 

--- a/bin/generate.sh
+++ b/bin/generate.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-LATEST_SPEC="https://raw.githubusercontent.com/localstack/openapi/refs/heads/main/openapi/emulators/localstack-spec-latest.yml"
-SPEC_URL="${1:-$LATEST_SPEC}"
+# Use the latest spec by default
+SPEC_URL="https://raw.githubusercontent.com/localstack/openapi/refs/heads/main/openapi/emulators/localstack-spec-latest.yml"
+
+if [ -n "$1" ]; then
+  SPEC_URL="https://github.com/localstack/openapi/releases/download/v$1/localstack-spec.yml"
+fi
 
 # Check if the URL is valid
 if ! wget --spider -q "$SPEC_URL"; then

--- a/bin/generate.sh
+++ b/bin/generate.sh
@@ -10,7 +10,7 @@ if ! wget --spider -q "$SPEC_URL"; then
 fi
 
 docker run --rm -v "${PWD}:/local" openapitools/openapi-generator-cli:v7.10.0 generate \
-    -i "$LATEST_SPEC" \
+    -i "$SPEC_URL" \
     --skip-validate-spec \
     -g python \
     -o /local//packages/localstack-sdk-generated \

--- a/bin/generate.sh
+++ b/bin/generate.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 
+LATEST_SPEC="https://raw.githubusercontent.com/localstack/openapi/refs/heads/main/openapi/emulators/localstack-spec-latest.yml"
+SPEC_URL="${1:-$LATEST_SPEC}"
+
+# Check if the URL is valid
+if ! wget --spider -q "$SPEC_URL"; then
+    echo "Spec URL seems not accessible: $SPEC_URL"
+    exit 1
+fi
+
 docker run --rm -v "${PWD}:/local" openapitools/openapi-generator-cli:v7.10.0 generate \
-    -i https://raw.githubusercontent.com/localstack/openapi/refs/heads/main/openapi/emulators/localstack-spec-latest.yml \
+    -i "$LATEST_SPEC" \
     --skip-validate-spec \
     -g python \
     -o /local//packages/localstack-sdk-generated \

--- a/requirements-spec.txt
+++ b/requirements-spec.txt
@@ -1,2 +1,0 @@
-localstack-core==3.8.1.dev4
-localstack-ext==3.8.1.dev1


### PR DESCRIPTION
So far, we have manually released the Python SDK, generating the code from the latest OpenAPI spec.
This PR introduces a workflow to automate this process.

Given a LS version in input, we:
- fetch the corresponding OpenAPI spec from the release artifacts in https://github.com/localstack/openapi;
- update the generated code (i.e., generating code from the fetched spec);
- pull the right LocalStack version and run the SDK test suite;
- create and tag a release commit;
- build and push to PyPi
- create a draft release of the SDK;
- create and push a dev version.

The workflow can be manually triggered on an arbitrary version of LS.
To properly integrate this into the release of LS, we can introduce a workflow triggered when a new OpenAPI spec is released that triggers this via `repository_dispatch`.