### PR TITLE
Fix Makefile - build all workspace packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ generate:			## Generate the code from the OpenAPI specs
 	./bin/generate.sh
 
 build:
-	uv build
+	uv build --all-packages
 
 publish: clean-dist build
 	uv publish


### PR DESCRIPTION
Without the `--all-packages` option, only the `localstack-sdk` distribution is built. 
To also build a distribution for the generated code, we need to add such an option.

Follow-up for https://github.com/localstack/localstack-sdk-python/pull/16