### PR TITLE
CI: Switch PyPI publishing to trusted publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ env:
 jobs:
   test_python:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: write
+      id-token: write
     env:
       RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.event.client_payload.version}}
 
@@ -93,7 +97,7 @@ jobs:
 
     - name: "Publish Release to PyPi"
       env:
-        UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
+        UV_PUBLISH_TRUSTED_PUBLISHING: always
       run: make publish
 
     - name: "Create GitHub Release"


### PR DESCRIPTION
## Summary

- Adds `environment: pypi` to the release job (the GitHub environment Alex created, restricted to `main`)
- Adds `permissions: id-token: write` (required for GitHub OIDC token) and `contents: write` (required for git push/tag)
- Replaces `UV_PUBLISH_TOKEN` secret with `UV_PUBLISH_TRUSTED_PUBLISHING: always` so `uv publish` requests an OIDC token from GitHub instead of using a password token

The PyPI trusted publisher policy and the `pypi` GitHub environment were already configured. This PR completes the workflow side.


## Test plan

- [ ] Trigger a release workflow run and confirm the publish step succeeds without `UV_PUBLISH_TOKEN`

## Related

COSY-772

🤖 Generated with [Claude Code](https://claude.com/claude-code)