### PR TITLE
CI: run LocalStack via lstk instead of the localstack PyPI package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
       id-token: write
     env:
       RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.event.client_payload.version}}
-      LSTK_CONFIG_FILE: ${{ runner.temp }}/lstk-config.toml
 
     steps:
     - name: "Pull Image (localstack/localstack-pro:${{ env.RELEASE_VERSION }})"
@@ -72,12 +71,13 @@ jobs:
       # The config pins the emulator image to the release version. It lives outside
       # the workspace so the "Check Uncommitted Changes" step stays clean.
       run: |
-        cat > "${LSTK_CONFIG_FILE}" <<EOF
+        cat > "${RUNNER_TEMP}/lstk-config.toml" <<EOF
         [[containers]]
         type = "aws"
         tag = "${RELEASE_VERSION}"
         port = "4566"
         EOF
+        echo "LSTK_CONFIG_FILE=${RUNNER_TEMP}/lstk-config.toml" >> "$GITHUB_ENV"
 
     - name: "Start Localstack"
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
       id-token: write
     env:
       RELEASE_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.event.client_payload.version}}
+      LSTK_CONFIG_FILE: ${{ runner.temp }}/lstk-config.toml
 
     steps:
     - name: "Pull Image (localstack/localstack-pro:${{ env.RELEASE_VERSION }})"
@@ -64,16 +65,26 @@ jobs:
     - name: "Install Project"
       run: make install-dev
 
-    - name: "Install LocalStack"
-      run: pip install localstack==${RELEASE_VERSION}
+    - name: "Install lstk"
+      run: npm install -g @localstack/lstk
+
+    - name: "Configure lstk"
+      # The config pins the emulator image to the release version. It lives outside
+      # the workspace so the "Check Uncommitted Changes" step stays clean.
+      run: |
+        cat > "${LSTK_CONFIG_FILE}" <<EOF
+        [[containers]]
+        type = "aws"
+        tag = "${RELEASE_VERSION}"
+        port = "4566"
+        EOF
 
     - name: "Start Localstack"
       env:
-       LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
-      run: |
-        source .venv/bin/activate
-        DEBUG=1 DISABLE_EVENTS="1" IMAGE_NAME="localstack/localstack-pro:${RELEASE_VERSION}" localstack start -d
-        localstack wait -t 120 || (python -m localstack.cli.main logs && false)
+        LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+        LOCALSTACK_DEBUG: "1"
+        LOCALSTACK_DISABLE_EVENTS: "1"
+      run: lstk --config "${LSTK_CONFIG_FILE}" start --timeout 2m
 
     - name: "Run Python Tests"
       env:
@@ -83,9 +94,8 @@ jobs:
     - name: "Stop Localstack"
       if: success() || failure()
       run: |
-        source .venv/bin/activate
-        localstack logs
-        localstack stop
+        lstk --config "${LSTK_CONFIG_FILE}" logs
+        lstk --config "${LSTK_CONFIG_FILE}" stop
 
     - name: "Check Uncommitted Changes"
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,21 +33,23 @@ jobs:
       run: |
         make install-dev
 
-    - name: Install LocalStack
+    - name: Install lstk
       run: |
-        pip install --pre --upgrade localstack
+        npm install -g @localstack/lstk
 
     - name: Pull image
       run: |
         docker pull localstack/localstack-pro
 
+    # lstk defaults to the aws emulator with image localstack/localstack-pro:latest,
+    # so no config file is needed here.
     - name: Start Localstack
       env:
-       LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+        LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+        LOCALSTACK_DEBUG: "1"
+        LOCALSTACK_DISABLE_EVENTS: "1"
       run: |
-          source .venv/bin/activate
-          DEBUG=1 DISABLE_EVENTS="1" IMAGE_NAME="localstack/localstack-pro:latest" localstack start -d
-          localstack wait -t 120 || (python -m localstack.cli.main logs && false)
+          lstk start --timeout 2m
 
     - name: Run Python Tests
       env:
@@ -58,6 +60,5 @@ jobs:
     - name: Stop Localstack
       if: always()
       run: |
-          source .venv/bin/activate
-          localstack logs
-          localstack stop
+          lstk logs
+          lstk stop


### PR DESCRIPTION
## Motivation

The release workflow installs `localstack==${RELEASE_VERSION}` from PyPI just to start LocalStack for the SDK tests. This couples the SDK release to the `localstack` package release (published separately via localstack-cli-standalone, with no retry on PyPI propagation lag) and stands in the way of the planned deprecation of that package. The pinned Docker image is the actual dependency; the pip package is only the launcher.

## Changes

- `release.yml`: install `lstk` via npm instead of `pip install localstack==$VERSION`; pin the emulator image through an lstk config file in `$RUNNER_TEMP` (outside the workspace, so the "Check Uncommitted Changes" gate stays clean). `lstk start --timeout 2m` replaces `start -d` + `wait` — it blocks until the emulator is healthy and dumps startup logs itself on failure. `logs`/`stop` pass the same `--config`, since the derived container name embeds the pinned tag.
- `test.yml`: same swap, no config file needed — lstk defaults to `localstack/localstack-pro:latest`.
- `DEBUG`/`DISABLE_EVENTS` become `LOCALSTACK_DEBUG`/`LOCALSTACK_DISABLE_EVENTS` (lstk forwards `LOCALSTACK_*` host env vars into the container).

The Docker image pull remains the only release-time dependency on LocalStack itself.

## Testing

Verified locally with lstk built from latest main: the exact pinned-style config plus `lstk --config … start --timeout 2m` / `logs` / `stop` all pass, with DEBUG output visible in the logs (env forwarding works). The `test.yml` path runs on this PR; the `release.yml` path is first exercised on the next release.

## Review

Workflow-only change. Worth a skim of the `release.yml` diff since that path only runs during an actual release. Notes for reviewers: `port` is required in an lstk `[[containers]]` block (omitting it fails validation), and a tag the license server can't parse degrades to in-container license validation instead of failing the start.

Closes COSY-856

🤖 Generated with [Claude Code](https://claude.com/claude-code)